### PR TITLE
feat: better handling of 'client.reconnect' message in Stratum protocol

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -1510,8 +1510,12 @@ static bool stratum_reconnect(struct stratum_ctx *sctx, json_t *params)
 		port = atoi(json_string_value(port_val));
 	else
 		port = (int) json_integer_value(port_val);
-	if (!host || !port)
-		return false;
+	if (!host || !port) {
+		// We just reconnect to the current Stratum server in this case
+		applog(LOG_NOTICE, "Server requested reconnection to %s", sctx->url);
+		stratum_disconnect(sctx);
+		return true;
+	}
 	
 	free(sctx->url);
 	sctx->url = (char*)malloc(32 + strlen(host));


### PR DESCRIPTION
### Update
Somehow, ccminer seems to be way better at detecting disconnection from the Stratum server than cpuminer.

During tests using our current image (which doesn't include this branch), it was able to reconnect immediately when tx-mining-service container was restarted:

```
[2022-01-25 19:48:32] GPU #0: Tesla M60, 631.03 MH/s
[2022-01-25 19:48:38] GPU #0: Tesla M60, 623.06 MH/s
[2022-01-25 19:48:39] Stratum connection interrupted
[2022-01-25 19:48:39] Stratum subscribe answer id is not correct!
[2022-01-25 19:48:42] GPU #0: Tesla M60, 619.91 MH/s
[2022-01-25 19:48:46] GPU #0: Tesla M60, 630.87 MH/s
```

So I think this PR is not crucial for ccminer

----------
### Acceptance Criteria
We should handle the `client.reconnect` message in Stratum protocol even if not host/port is sent in the params.

In this case, we will default to reconnecting to the current server.

This is the behavior described in https://en.bitcoin.it/wiki/Stratum_mining_protocol#client.reconnect

### TODO
- [ ] We should make sure the current version of our ccminer is really the one in the master branch before releasing this