### PR TITLE
feat: upgrade to cuda 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-devel as builder
+FROM nvidia/cuda:11.0-devel as builder
 
 RUN apt-get -y update && \
     apt-get -y install \
@@ -13,7 +13,7 @@ RUN cd /tmp/ccminer && \
     ./configure --with-cuda=/usr/local/cuda && \
     make
 
-FROM nvidia/cuda:10.0-base
+FROM nvidia/cuda:11.0-base
 
 RUN apt-get -y update && \
     apt-get -y install \

--- a/Makefile.am
+++ b/Makefile.am
@@ -123,8 +123,6 @@ nvcc_ARCH :=
 #nvcc_ARCH += -gencode=arch=compute_61,code=\"sm_61,compute_61\" # CUDA 8
 nvcc_ARCH += -gencode=arch=compute_52,code=\"sm_52,compute_52\"
 #nvcc_ARCH += -gencode=arch=compute_50,code=\"sm_50,compute_50\"
-#nvcc_ARCH += -gencode=arch=compute_35,code=\"sm_35,compute_35\"
-#nvcc_ARCH += -gencode=arch=compute_30,code=\"sm_30,compute_30\"
 
 nvcc_FLAGS = $(nvcc_ARCH) @CUDA_INCLUDES@ -I. @CUDA_CFLAGS@
 nvcc_FLAGS += $(JANSSON_INCLUDES) --ptxas-options="-v"
@@ -182,27 +180,7 @@ quark/cuda_quark_compactionTest.o: quark/cuda_quark_compactionTest.cu
 JHA/cuda_jha_compactionTest.o: JHA/cuda_jha_compactionTest.cu
 	$(NVCC) $(nvcc_FLAGS) --maxrregcount=80 -o $@ -c $<
 
-# This object does not use cuda device code but call the different kernels (autotune)
-scrypt/salsa_kernel.o: scrypt/salsa_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
 # These kernels are for older devices (SM)
-
-scrypt/test_kernel.o: scrypt/test_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/fermi_kernel.o: scrypt/fermi_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/kepler_kernel.o: scrypt/kepler_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/nv_kernel.o: scrypt/nv_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/titan_kernel.o: scrypt/titan_kernel.cu
-	$(NVCC) $(nvcc_FLAGS) -gencode=arch=compute_35,code=\"sm_35,compute_35\" -o $@ -c $<
-
 skein.o: skein.cu
 	$(NVCC) $(nvcc_FLAGS) --maxrregcount=64 -o $@ -c $<
 


### PR DESCRIPTION
### Acceptance Criteria
We should be able to build the project in Linux Kernel 5.10

### Motivation
To support newer kernels, we apparently need to use newer versions of the Nvidia drivers, which come with cuda 11.

I had problems while trying to run this ccminer in a AWS instance which came with kernel 5.10 (this gist has the steps I followed: https://gist.github.com/luislhl/6314f4570272c04d5aa8d62006b6c0b8)

The drivers can be searched in https://www.nvidia.com/download/index.aspx?lang=en-us

According to this, only from driver 460.39 there is support for linux kernel 5.10: https://www.nvidia.com/Download/driverResults.aspx/170134/en-us

### Explanation
This PR is inspired in this comment: https://bitcointalk.org/index.php?topic=770064.msg58407918#msg58407918

More about nvidia architectures: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/

### Notes
This will drop support for older GPUs, maybe we need to better check which ones.