### PR TITLE
feat: support CUDA 11

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         cuda-version:
-        - 11.0
-        - 10.0
+        - "11.0"
+        - "10.0"
     steps:
     - name: Prepare tags
       id: tags

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,68 @@
+name: docker
+on:
+  push:
+    tags:
+    - v*
+    branches:
+    - master
+    # TODO: Remove this branch
+    - feat/support-cuda-11
+
+jobs:
+  # Builds and pushes the Docker image to Docker Hub and ECR
+  docker-build-push:
+    name: docker-build-push cuda ${{ matrix.cuda-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cuda-version:
+        - 11.0
+        - 10.0
+    steps:
+    - name: Prepare tags
+      id: tags
+      shell: python
+      run: |
+        base_dockerhub_tag = 'docker.io/hathornetwork/ccminer:'
+
+        tags = set()
+
+        # Set tag suffix using CUDA version
+        suffix = '-cuda-${{ matrix.cuda-version }}'
+
+        # Create the tags
+        ref = '${{ github.ref }}'
+        if ref.startswith('refs/tags/'):
+            version = ref[10:].split('-', 1)[0]
+
+            tags.add(base_dockerhub_tag + version + suffix)
+            tags.add(base_dockerhub_tag + 'latest' + suffix)
+
+            # Cuda 11.0 is our default for generating the generic tags
+            if '${{ matrix.cuda-version }}' == '11.0':
+              tags.add(base_dockerhub_tag + version)
+              tags.add(base_dockerhub_tag + 'latest')
+        elif ref == 'refs/heads/master':
+            tags.add(base_dockerhub_tag + 'beta' + suffix)
+        else:
+            tags.add(base_dockerhub_tag + 'testing' + suffix)
+
+        print("::set-output name=tags::" + ",".join(tags))
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+    - name: Login to DockerHub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      with:
+        build-args: CUDA=${{ matrix.cuda-version }}
+        push: true
+        tags: ${{ steps.tags.outputs.tags }}
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:11.0-devel as builder
+ARG CUDA=11.0
+FROM nvidia/cuda:$CUDA-devel as builder
 
 RUN apt-get -y update && \
     apt-get -y install \
@@ -13,7 +14,7 @@ RUN cd /tmp/ccminer && \
     ./configure --with-cuda=/usr/local/cuda && \
     make
 
-FROM nvidia/cuda:11.0-base
+FROM nvidia/cuda:$CUDA-base
 
 RUN apt-get -y update && \
     apt-get -y install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-devel as builder
+FROM nvidia/cuda:11.0-devel as builder
 
 RUN apt-get -y update && \
     apt-get -y install \
@@ -13,7 +13,7 @@ RUN cd /tmp/ccminer && \
     ./configure --with-cuda=/usr/local/cuda && \
     make
 
-FROM nvidia/cuda:10.0-base
+FROM nvidia/cuda:11.0-base
 
 RUN apt-get -y update && \
     apt-get -y install \

--- a/Makefile.am
+++ b/Makefile.am
@@ -123,8 +123,6 @@ nvcc_ARCH :=
 #nvcc_ARCH += -gencode=arch=compute_61,code=\"sm_61,compute_61\" # CUDA 8
 nvcc_ARCH += -gencode=arch=compute_52,code=\"sm_52,compute_52\"
 #nvcc_ARCH += -gencode=arch=compute_50,code=\"sm_50,compute_50\"
-#nvcc_ARCH += -gencode=arch=compute_35,code=\"sm_35,compute_35\"
-#nvcc_ARCH += -gencode=arch=compute_30,code=\"sm_30,compute_30\"
 
 nvcc_FLAGS = $(nvcc_ARCH) @CUDA_INCLUDES@ -I. @CUDA_CFLAGS@
 nvcc_FLAGS += $(JANSSON_INCLUDES) --ptxas-options="-v"
@@ -182,27 +180,7 @@ quark/cuda_quark_compactionTest.o: quark/cuda_quark_compactionTest.cu
 JHA/cuda_jha_compactionTest.o: JHA/cuda_jha_compactionTest.cu
 	$(NVCC) $(nvcc_FLAGS) --maxrregcount=80 -o $@ -c $<
 
-# This object does not use cuda device code but call the different kernels (autotune)
-scrypt/salsa_kernel.o: scrypt/salsa_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
 # These kernels are for older devices (SM)
-
-scrypt/test_kernel.o: scrypt/test_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/fermi_kernel.o: scrypt/fermi_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/kepler_kernel.o: scrypt/kepler_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/nv_kernel.o: scrypt/nv_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
-
-scrypt/titan_kernel.o: scrypt/titan_kernel.cu
-	$(NVCC) $(nvcc_FLAGS) -gencode=arch=compute_35,code=\"sm_35,compute_35\" -o $@ -c $<
-
 skein.o: skein.cu
 	$(NVCC) $(nvcc_FLAGS) --maxrregcount=64 -o $@ -c $<
 


### PR DESCRIPTION
Moved from: https://github.com/HathorNetwork/ccminer/pull/5

### Acceptance Criteria
- We should be able to build the project in Linux Kernel 5.10
- We should build Docker images using Github Actions

### Motivation
To support newer kernels, we apparently need to use newer versions of the Nvidia drivers, which come with cuda 11.

I had problems while trying to run this ccminer in a AWS instance which came with kernel 5.10 (this gist has the steps I followed: https://gist.github.com/luislhl/6314f4570272c04d5aa8d62006b6c0b8)

The drivers can be searched in https://www.nvidia.com/download/index.aspx?lang=en-us

According to this, only from driver 460.39 there is support for linux kernel 5.10: https://www.nvidia.com/Download/driverResults.aspx/170134/en-us

### Explanation
This PR is inspired in this comment: https://bitcointalk.org/index.php?topic=770064.msg58407918#msg58407918

More about nvidia architectures: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/

More about cuda versions: https://docs.nvidia.com/deploy/cuda-compatibility/

### Notes
This will drop support for some older GPUs, like the following (but maybe not limited to them):
- Tesla K40 (released in 2013)
- GeForce 700 series (released in 2013)
- Tesla K80 (released in 2014)