### PR TITLE
fix: remove branch from github actions job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,6 @@ on:
     - v*
     branches:
     - master
-    # TODO: Remove this branch
-    - feat/support-cuda-11
 
 jobs:
   # Builds and pushes the Docker image to Docker Hub and ECR


### PR DESCRIPTION
A TODO was merged by mistake in the last PR