### PR TITLE
fix: update CUDA Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG CUDA=11.0
-FROM nvidia/cuda:$CUDA-devel as builder
+ARG CUDA=11.6.1
+FROM nvidia/cuda:$CUDA-devel-ubuntu20.04 as builder
 
 RUN apt-get -y update && \
     apt-get -y install \
@@ -14,7 +14,7 @@ RUN cd /tmp/ccminer && \
     ./configure --with-cuda=/usr/local/cuda && \
     make
 
-FROM nvidia/cuda:$CUDA-base
+FROM nvidia/cuda:$CUDA-base-ubuntu20.04
 
 RUN apt-get -y update && \
     apt-get -y install \


### PR DESCRIPTION
### Acceptance Criteria

- The build of the Docker image should work. Previously it was using an image tag that has been deprecated.
- We should continue using CUDA 11. CUDA 12 will present errors that would need additional changes and investigation, although it might be a good idea to do this eventually (like we did in https://github.com/HathorNetwork/ccminer/pull/6 to migrate from CUDA 10 to 11)